### PR TITLE
Update App.test.js to check search bar label

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders search bar label', () => {
+  render(<App />);
+  const searchInput = screen.getByLabelText('Search...');
+  expect(searchInput).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update test to look for Material-UI `Search...` label instead of CRA boilerplate

## Testing
- `npm test --silent -- --watchAll=false` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c984497a083318749d723b931c47a